### PR TITLE
Fix distance value of the ol.cluster layer for GeoJSON layer.

### DIFF
--- a/src/ol-map-logic/GeoJSONFeaturesLayer.js
+++ b/src/ol-map-logic/GeoJSONFeaturesLayer.js
@@ -23,7 +23,7 @@ class GeoJSONFeaturesLayer extends ClusteredFeaturesLayer {
     get olLayer() {
         const layer = new VectorLayer({
             source: new Cluster({
-                distance: 80,
+                distance: 0.0005,
                 source: new SourceVector({
                     url: this.source_url + '?time='+ new Date().getTime(),
                     format: new GeoJSON()


### PR DESCRIPTION
Since we use the [useGeographic()](https://openlayers.org/en/latest/examples/geographic.html) function of openlayers (for the map state in the url), the distance value of the ol.cluster layer seems wrong. An issue has already been opened on the openlayers repo concerning that: https://github.com/openlayers/openlayers/issues/11986.

For now, I have set a way lowest value to the distance parameter of the ol.cluster layer which gives good results.