### PR TITLE
Prevent crashes when fetching layer files without CORS header.

### DIFF
--- a/src/components/LayersList.js
+++ b/src/components/LayersList.js
@@ -52,20 +52,27 @@ const LayersList = ( { selectedLayer, setSelectedLayer } ) => {
             method: 'GET',
             cache: 'no-cache'
         };
-        const layersResponse = await fetch(`${config.WEB_PATH}/layers.json`, requestInit);
-        if (layersResponse.ok) {
-            const layersList = await layersResponse.json();
-            const loadedLayers = []
-            for (const layerURL of layersList.layers) {
-                const layerResponse = await fetch(layerURL, requestInit);
-                if (layerResponse.ok) {
-                    const layerData = await layerResponse.json();
-                    loadedLayers.push(layerData);
+        try {
+            const layersResponse = await fetch(`${config.WEB_PATH}/layers.json`, requestInit);
+            if (layersResponse.ok) {
+                const layersList = await layersResponse.json();
+                const loadedLayers = []
+                for (const layerURL of layersList.layers) {
+                    try {
+                        const layerResponse = await fetch(layerURL, requestInit);
+                        if (layerResponse.ok) {
+                            const layerData = await layerResponse.json();
+                            loadedLayers.push(layerData);
+                        }
+                    } catch (error) {
+                        console.warn('Error while loading the layer: ' + layerURL + ' from the server');
+                    }
                 }
+                setLayers(loadedLayers);
             }
-            setLayers(loadedLayers);
+        } catch (error) {
+            console.warn('Error while loading the layers list from the server.');
         }
- 
     }
 
     return (


### PR DESCRIPTION
Fixes #10

Manually catch exceptions raised by the fetch() method when receiving responses without CORS header (only inside the LayersList component).

This was especially problematic when one specific layer.json file doesn't exist on the server, if the 404 response returned doesn't contain a CORS header, the fetch() method doesn't accept the response and raise an exception. See [stackoverflow](https://stackoverflow.com/questions/48865254/fetch-rejects-promise-on-404-responses-instead-of-resolving-with-404-status).

A warning is now displayed in the console instead of crashing the app.