### PR TITLE
remove Firefox warning

### DIFF
--- a/src/components/InformationPanel.js
+++ b/src/components/InformationPanel.js
@@ -32,9 +32,6 @@ const InformationPanel = ({ setInfoPanelDisplayed }) => {
                 <p>
                     We do not have a "report false positive" feature implemented yet. If you find a lot of data which should not be considered as errors, please come to the "Issues" section of the <a href='https://github.com/AntoJvlt/Nominatim-Data-Analyser/issues' target='_blank' rel="noreferrer">github repository</a> to discuss this.
                 </p>
-                <p className='italic-text'>
-                    /!\ You might encounter some performance issues with some layers if you are using the Firefox browser. Please switch to another browser if this is the case. /!\
-                </p>
             </Scrollbars>
         </section>
     )


### PR DESCRIPTION
fixes #20

Note: I have not really tested it.

BTW, thanks to @AntoJvlt and @lonvia for this tool! I already found and fixed some issues, it will be a great thing to link when someone complains that geocoding is broken.