### PR TITLE
Change default URL for QA tiles

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,3 +1,3 @@
 {
-    "WEB_PATH": "https://longma.openstreetmap.org/qa-data"
+    "WEB_PATH": "https://qa-tile.nominatim.openstreetmap.org"
 }


### PR DESCRIPTION
This is hopefully the last time that the URL changes. We've now set up a separate DNS entry for the QA tiles which is more permanent than what we had before.

The URL may now be advertised and used by others. However, the rule is that only https://qa-tile.nominatim.openstreetmap.org/layers.json is guaranteed to be stable. The URL of each QA layer should be read from that to ensure it is still up-to-date.