### PR TITLE
Set layer URL via environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
+    "@rollup/plugin-virtual": "^2.0.3",
     "@tsconfig/svelte": "^2.0.0",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,9 +6,16 @@ import { terser } from 'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';
 import css from 'rollup-plugin-css-only';
+import virtual from '@rollup/plugin-virtual';
 import json from '@rollup/plugin-json';
 
 const production = !process.env.ROLLUP_WATCH;
+
+const web_path = process.env.NOMINATIM_QA_WEBPATH || 'https://qa-tile.nominatim.openstreetmap.org';
+
+function export_str(content) {
+	return `export default '` + content + `'`;
+}
 
 function serve() {
 	let server;
@@ -40,6 +47,7 @@ export default {
 		file: 'public/build/bundle.js'
 	},
 	plugins: [
+		virtual({'CFG_WEB_PATH': export_str(web_path)}),
 		svelte({
 			preprocess: sveltePreprocess({ sourceMap: !production }),
 			compilerOptions: {

--- a/src/components/layers/LayersList.svelte
+++ b/src/components/layers/LayersList.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
     import ILayer from '../../model/ILayer';
-    import config from '../../config/config.json';
+    import web_path from 'CFG_WEB_PATH';
     import ILayersList from '../../model/ILayersList';
     import {onMount} from 'svelte';
     import {Wave} from 'svelte-loading-spinners';
@@ -22,7 +22,7 @@
         };
 
         try {
-            const layersResponse = await fetch(`${config.WEB_PATH}/layers.json`, requestInit);
+            const layersResponse = await fetch(`${web_path}/layers.json`, requestInit);
             if (layersResponse.ok) {
                 const layersList: ILayersList = await layersResponse.json();
                 loadEachLayer(requestInit, layersList).then((layers) => {

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,3 +1,0 @@
-{
-    "WEB_PATH": "https://longma.openstreetmap.org/qa-data"
-}


### PR DESCRIPTION
This uses the [rollup virutal plugin](https://github.com/rollup/plugins/tree/master/packages/virtual) to take the layer URL (formally `WEB_PATH`) from the (optional) environment variable `NOMINATIM_QA_WEBPATH` and inject it into the build process. This setup has the big advantage that it becomes a lot easier to switch between different QA tile servers (i.e. switching between my dev server and the official one).

I haven't rebuild the `yarn.lock` file because I'm on yarn 3.0 which seems to produce a completely different file. Furthermore I think that the json plugin can now be removed but I'm not entirely sure.