### PR TITLE
Fix hidden text for the layer description on the left menu.

### DIFF
--- a/src/components/layers/Layer.svelte
+++ b/src/components/layers/Layer.svelte
@@ -77,7 +77,7 @@
     }
 
     .layer-data-wrapper.layer-data-toggle {
-        max-height: 500px;
+        max-height: 10000px;
         transition: max-height 0.5s ease-in;
     }
 


### PR DESCRIPTION
Fixed a bug where long texts for an opened layer on the left menu was not completely displayed. This was because of a max-height too small. This max-height is only there for the transition effect to work.